### PR TITLE
Added low battery binary sensor for devices

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -113,6 +113,7 @@ translating between the MQTT client and the LifeSOS ethernet adapter.
        #  auto_reset_interval: 180
        #  ha_name: "Lounge Motion"
        #  ha_name_rssi: "Lounge Motion RSSI"
+       #  ha_name_battery: "Lounge Motion Battery"
 
      # Uncomment any switches you own and provide a topic
      switches:
@@ -196,6 +197,11 @@ Assistant, these settings can either be ignored or removed.
    configuration needed to monitor the signal strength will be exported
    to Home Assistant, and the value will be used as the display name
    for the sensor.
+-  **ha_name_battery**: When this setting is listed under the device, the
+   configuration needed to monitor the battery status (Using `BatteryLow`/
+   `PowerOnReset` events for the device) will be exported to Home Assistant,
+   and the value will be used as the display name for the binary sensor.
+
 
 Logger settings
 ---------------

--- a/lifesospy_mqtt/config.py
+++ b/lifesospy_mqtt/config.py
@@ -24,6 +24,7 @@ CONF_HA_BIRTH_TOPIC = 'ha_birth_topic'
 CONF_HA_DISCOVERY_PREFIX = 'ha_discovery_prefix'
 CONF_HA_NAME = 'ha_name'
 CONF_HA_NAME_RSSI = 'ha_name_rssi'
+CONF_HA_NAME_BATTERY = 'ha_name_battery'
 CONF_HOST = 'host'
 CONF_NAMESPACES = 'namespaces'
 CONF_PASSWORD = 'password'
@@ -90,6 +91,7 @@ DEFAULT_CONFIG = """
     #  """ + CONF_TOPIC + """: home/front/door
     #  """ + CONF_HA_NAME + """: "Front Door"
     #  """ + CONF_HA_NAME_RSSI + """: "Front Door RSSI"
+    #  """ + CONF_HA_NAME_BATTERY + """: "Front Door Battery"
     #- """ + CONF_DEVICE_ID + """: '123abc'
     #  """ + CONF_TOPIC + """: home/lounge/motion
     #  """ + CONF_AUTO_RESET_INTERVAL + """: 180
@@ -394,6 +396,7 @@ class TranslatorDeviceConfig(object):
         self._auto_reset_interval = settings.get(CONF_AUTO_RESET_INTERVAL)
         self._ha_name = settings.get(CONF_HA_NAME)
         self._ha_name_rssi = settings.get(CONF_HA_NAME_RSSI)
+        self._ha_name_battery = settings.get(CONF_HA_NAME_BATTERY)
 
     @property
     def auto_reset_interval(self) -> int:
@@ -411,18 +414,25 @@ class TranslatorDeviceConfig(object):
         return self._ha_name_rssi
 
     @property
+    def ha_name_battery(self) -> str:
+        """Name to assign the device's battery status in Home Assistant."""
+        return self._ha_name_battery
+
+    @property
     def topic(self) -> str:
         """Topic for the device."""
         return self._topic
 
     def __repr__(self):
-        return "<{}: topic={}, auto_reset_interval={}, ha_name={}, ha_name_rssi={}>".format(
-            self.__class__.__name__,
-            self._topic,
-            self._auto_reset_interval,
-            self._ha_name,
-            self._ha_name_rssi,
-        )
+        return "<{}: topic={}, auto_reset_interval={}, ha_name={}, " \
+               "ha_name_rssi={}, ha_name_battery={}>".format(
+                self.__class__.__name__,
+                self._topic,
+                self._auto_reset_interval,
+                self._ha_name,
+                self._ha_name_rssi,
+                self._ha_name_battery,
+                )
 
 
 class TranslatorSwitchConfig(object):


### PR DESCRIPTION
Fixes #9 

Adds a new Translator device setting called `ha_name_battery` that will expose a binary_sensor to Home Assistant.